### PR TITLE
swap file を消すようにした

### DIFF
--- a/plugin/restart.vim
+++ b/plugin/restart.vim
@@ -309,6 +309,10 @@ function! s:restart(bang) "{{{
     endif
 
     wviminfo
+
+    " Delete all buffers to delete the swap files.
+    silent execute '1,' . bufnr('$') . 'bwipeout'
+
     call s:spawn(spawn_args)
 
     execute 'qall' . (a:bang ? '!' : '')


### PR DESCRIPTION
新しいVimの起動タイミングによっては、まだ古いswap fileが残っていて警告が出てしまうので、新しいVimの起動前に全バッファを消すことによりswap fileを消すようにしてみました。
