### PR TITLE
Accept various ret-val types.

### DIFF
--- a/autoload/restart.vim
+++ b/autoload/restart.vim
@@ -163,7 +163,7 @@ function! restart#restart(bang, args) abort "{{{
         for ex in type(r) == type([]) ? r : [r]
             let spawn_args += ['-c', ex]
         endfor
-        unlet Fn
+        unlet r Fn
     endfor
 
     if g:restart_sessionoptions != ''


### PR DESCRIPTION
`g:restart_save_fn` に設定できる関数の返り値を
1. 文字列を返す関数
2. 文字列のリストを返す関数

どちらでもOK(混在もOK)に修正します。

本来、そういう仕様なのだと思いますが、現状のコードだと、1か2どちらかで統一しないとエラーになります。

g:restart_save_fn にはデフォルトで `s:save_window_values` が設定されており、この関数は2.の文字列リストを返すため、実質的に2.の文字列リストを返す関数しか設定できなくなっています。
