### PR TITLE
MacVim: Fix previous window is not closed after new one opened

### DIFF
--- a/autoload/restart.vim
+++ b/autoload/restart.vim
@@ -39,8 +39,12 @@ function! s:spawn(command) "{{{
         " cmd.exe appears and won't close.
         execute printf('silent !start %s', a:command)
     elseif s:is_macvim
-        " TODO: Support a:command
-        macaction newWindow:
+        if executable(g:restart_vim_progname)
+            execute printf('silent !%s', a:command)
+        else
+            " Fallback.
+            macaction newWindow:
+        endif
     else
         execute printf('silent !%s', a:command)
     endif

--- a/doc/restart.txt
+++ b/doc/restart.txt
@@ -86,7 +86,7 @@ g:restart_save_fn	*g:restart_save_fn*
 	- getwinposy()
 
 g:restart_vim_progname	*g:restart_vim_progname*
-					(default: "gvim")
+					(default: "gvim" (or "mvim" on Mac))
 	Vim program name to restart.
 
 	FIXME:

--- a/plugin/restart.vim
+++ b/plugin/restart.vim
@@ -19,6 +19,9 @@ if !exists('g:restart_save_fn')
 endif
 if !exists('g:restart_vim_progname')
     let g:restart_vim_progname = 'gvim'
+    if has('gui_macvim') && executable('mvim')
+        let g:restart_vim_progname = 'mvim'
+    endif
 endif
 if !exists('g:restart_sessionoptions')
     let g:restart_sessionoptions = ''


### PR DESCRIPTION
MacVim 上で `:Restart` すると古い MacVim が閉じずに残ってしまっていました．これは `:macaction` を使って新しいウィンドウを開いてるのが原因っぽくて，他の環境と同様に `gvim` コマンドで新しい MacVim を開いてやると直りました．

ただ `gvim` コマンドは Mac だと無い場合がある（MacVim のインストール方法次第）ので、より確実にある `mvim` がデフォルト値になるようにしました（`gvim` は `mvim` へのシンボリックリンク）．

ちなみにドキュメントの TODO にある `g:restart_sessionoptions` が効かないという問題がこれで解消されているかどうかは確認できていないです．